### PR TITLE
Cognito - forgot password, account for verification code not being a number

### DIFF
--- a/src/routes/ResetPassword/ResetPassword.spec.js
+++ b/src/routes/ResetPassword/ResetPassword.spec.js
@@ -1,0 +1,42 @@
+import ElementUI from 'element-ui';
+import { createLocalVue, mount } from 'vue-test-utils'
+
+import ResetPassword from './ResetPassword.vue'
+
+const localVue = createLocalVue()
+localVue.use(ElementUI)
+
+const $route = {
+  path: "/password",
+  query: {
+    verificationCode: "$134322",
+    email: "cameron%2Bcognito%2Buser%40blackfynn.com"
+  },
+  params: {},
+  fullPath: "/password?verificationCode=%24134322&email=cameron%2Bcognito%2Buser%40blackfynn.com",
+  name: "password",
+  meta: {}
+}
+
+describe('ResetPassword.vue', () => {
+  let cmp
+
+  beforeEach(() => {
+    cmp = mount(ResetPassword, {
+      localVue,
+      mocks: {
+        $route
+      }
+    })
+  })
+
+  it('Email is decoded and displayed in the input', () => {
+    const inputEmail = cmp.vm.$refs.passwordFormEmail
+    expect(inputEmail.value).toBe('cameron+cognito+user@blackfynn.com')
+  })
+
+  it('Verification code is displayed in the input', () => {
+    const inputEmail = cmp.vm.$refs.passwordFormCode
+    expect(inputEmail.value).toBe('$134322')
+  })
+})

--- a/src/routes/ResetPassword/ResetPassword.vue
+++ b/src/routes/ResetPassword/ResetPassword.vue
@@ -88,6 +88,7 @@
               prop="email"
             >
               <el-input
+                ref="passwordFormEmail"
                 v-model="passwordForm.email"
                 placeholder="Email"
               />
@@ -97,8 +98,8 @@
               prop="code"
             >
               <el-input
+                ref="passwordFormCode"
                 v-model="passwordForm.code"
-                type="number"
                 placeholder="Verification Code"
               />
             </el-form-item>
@@ -270,10 +271,6 @@ export default {
         return `${apiUrl}/account/reset`
       }
       return ''
-    },
-
-    foo: function() {
-      return encodeURI(this.$route.query.email)
     }
   },
 
@@ -286,7 +283,7 @@ export default {
     },
     '$route.query.email': {
       handler(val) {
-        this.passwordForm.email = encodeURI(val)
+        this.passwordForm.email = decodeURIComponent(val)
       },
       immediate: true
     }

--- a/test/unit/__mocks__/styleMock.js
+++ b/test/unit/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/unit/jest.conf.js
+++ b/test/unit/jest.conf.js
@@ -10,7 +10,8 @@ module.exports = {
     'vue'
   ],
   moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1'
+    '^@/(.*)$': '<rootDir>/src/$1',
+    "\\.(css)$": "<rootDir>/test/unit/__mocks__/styleMock.js" // https://jestjs.io/docs/webpack#handling-static-assets
   },
   transform: {
     '^.+\\.js$': '<rootDir>/node_modules/babel-jest',


### PR DESCRIPTION
# Description

The purpose of this PR is to change the verification code input field from a `type=number` to a normal input field. This will account for the verification code not being a number.

## Clickup Ticket

[p30yzu](https://app.clickup.com/t/p30yzu)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Visiting http://localhost:3000/password?verificationCode=%24134322&email=cameron%2Bcognito%2Buser%40blackfynn.com will populate the fields correctly
- Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
