### PR TITLE
fix(Authentication): Store new token

### DIFF
--- a/src/components/check-active-user/CheckActiveUser.vue
+++ b/src/components/check-active-user/CheckActiveUser.vue
@@ -3,6 +3,7 @@
 <script>
 import { mapActions, mapGetters } from 'vuex'
 import Auth from '@aws-amplify/auth'
+import Cookies from 'js-cookie'
 
 import EventBus from '@/utils/event-bus'
 
@@ -11,8 +12,8 @@ export default {
 
   data() {
     return {
-      // interval to poll user session 5 minutes
-      interval: 3e5,
+      // interval to poll user session 4 minutes
+      interval: 240000,
       // async request reference
       pingUserHandle: null
     }
@@ -59,7 +60,9 @@ export default {
       this.pingUserHandle = setTimeout(() => {
         Auth.currentSession()
           .then((data) => {
-            this.updateUserToken(data.accessToken.jwtToken).then(() => this.pingUserActive())
+            const token = data.accessToken.jwtToken
+            Cookies.set('user_token', token)
+            this.updateUserToken(token).then(() => this.pingUserActive())
           })
           .catch(() => {
             this.callLogout()


### PR DESCRIPTION
# Description

The purpose of this PR is to store the new token when requesting the current sessions. Amplify will refresh and return this token if it is expired using this method. Before, I wasn't updating the token in Vuex, so the next request after that token was expired would use the old token.

## Clickup Ticket

[rx3cdp](https://app.clickup.com/t/rx3cdp)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Using VueDevtools, watch for Vuex actions `UPDATE_USER_TOKEN`. This is the user token being set after `currentSession()`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
