### PR TITLE
feat(Signup): Show error message if user has already been created

### DIFF
--- a/src/components/SetupProfile/SetupProfile.vue
+++ b/src/components/SetupProfile/SetupProfile.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="wrapper">
     <div
-      v-if="!isUserAlreadyCreated"
+      v-if="!isUserSignInFailed"
       class="login-wrap"
     >
       <h2 class="sharp-sans">
@@ -106,7 +106,7 @@
       </p>
     </div>
     <div
-      v-if="isUserAlreadyCreated"
+      v-if="isUserSignInFailed"
       class="login-wrap"
     >
       <h2 class="sharp-sans">
@@ -203,7 +203,7 @@ export default {
       isSavingProfile: false,
       isPasswordFormValid: false,
       user: {},
-      isUserAlreadyCreated: false
+      isUserSignInFailed: false
     }
   },
 
@@ -270,7 +270,8 @@ export default {
          this.user = await Auth.signIn(this.$route.params.username, this.$route.params.password)
          this.setupProfile()
         } catch (error) {
-          this.handleFailedSignIn(error)
+          this.isSavingProfile = false
+          this.isUserSignInFailed = true
         }
     },
 
@@ -343,25 +344,6 @@ export default {
         EventBus.$emit('login', loginBody)
       })
       .catch(this.handleFailedUserCreation.bind(this))
-    },
-
-    /**
-     * Handle failed responsed to sign the user in before
-     * account creation
-     * @param {Object} error
-     */
-    handleFailedSignIn: function(error) {
-      this.isSavingProfile = false
-      if (error.code === 'NotAuthorizedException') {
-        this.isUserAlreadyCreated = true
-      } else {
-        EventBus.$emit('toast', {
-          detail: {
-            type: 'error',
-            msg: error.message
-          }
-        })
-      }
     },
 
     /**


### PR DESCRIPTION
# Description
The purpose of this PR is to show an error message if user has already been created.

## Clickup Ticket

[rx2w7k](https://app.clickup.com/t/rx2w7k)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Invite a user to an org and complete the profile setup (on localhost)
- Ensure you're signed out, and using the link from the email for the user to setup, try to complete the form again.
- You should see a new message saying the user is already set up
- Click on "I forgot my password"
- A success toast should appear and you should receive a reset password email

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
