### PR TITLE
Link ORCID dialog - change button copy

### DIFF
--- a/src/components/LinkOrcidDialog/LinkOrcidDialog.vue
+++ b/src/components/LinkOrcidDialog/LinkOrcidDialog.vue
@@ -27,7 +27,7 @@
             class="primary"
             @click="openORCID"
           >
-            Relink ORCID
+            Link ORCID
           </bf-button>
         </div>
       </dialog-body>


### PR DESCRIPTION
# Description

The purpose of this PR is to change the button's copy for the link ORCID dialog to "Link ORCID".

## Clickup Ticket

[rx9b4w](https://app.clickup.com/t/rx9b4w)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The button's copy should say "Link ORCID"

If the dialog isn't open, using vue devtools, inspect `App` and set `isLinkOrcidDialogVisible` to `true`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
