### PR TITLE
Add environment to Intercom

### DIFF
--- a/src/components/analytics/Analytics.vue
+++ b/src/components/analytics/Analytics.vue
@@ -8,28 +8,6 @@ import EventBus from '../../utils/event-bus'
 import { path, pathOr, compose, last, split, prop, propOr, has, defaultTo, find, pathEq } from 'ramda'
 
 export default Vue.component('bf-analytics', {
-  /**
-   * Life cycle method
-   */
-  mounted: function() {
-    // Custom event handlers
-    // @TODO enable when adding Heap and Google Analytics
-    EventBus.$on('track-page', this.trackPage.bind(this))
-    // EventBus.$on('track-user', this.trackUser.bind(this))
-    EventBus.$on('track-event', this.trackEvent.bind(this))
-    // Google analytics
-    ga('create', site.googleAnalytics, 'auto')
-    // Intercom
-    this.$store.watch(this.getActiveOrganization, this.bootIntercom.bind(this))
-  },
-
-  beforeDestroy() {
-    // @TODO enable when adding Heap and Google Analytics
-    EventBus.$off('track-page', this.trackPage.bind(this))
-    // EventBus.$off('track-user', this.trackUser.bind(this))
-    EventBus.$off('track-event', this.trackEvent.bind(this))
-  },
-
   computed: {
     ...mapGetters([
       'getActiveOrganization',
@@ -54,6 +32,27 @@ export default Vue.component('bf-analytics', {
       return pathOr('', ['organization', 'id'], this.activeOrganization)
     }
   },
+  /**
+   * Life cycle method
+   */
+  mounted: function() {
+    // Custom event handlers
+    // @TODO enable when adding Heap and Google Analytics
+    EventBus.$on('track-page', this.trackPage.bind(this))
+    // EventBus.$on('track-user', this.trackUser.bind(this))
+    EventBus.$on('track-event', this.trackEvent.bind(this))
+    // Google analytics
+    ga('create', site.googleAnalytics, 'auto')
+    // Intercom
+    this.$store.watch(this.getActiveOrganization, this.bootIntercom.bind(this))
+  },
+
+  beforeDestroy() {
+    // @TODO enable when adding Heap and Google Analytics
+    EventBus.$off('track-page', this.trackPage.bind(this))
+    // EventBus.$off('track-user', this.trackUser.bind(this))
+    EventBus.$off('track-event', this.trackEvent.bind(this))
+  },
 
   methods: {
     /**
@@ -74,7 +73,8 @@ export default Vue.component('bf-analytics', {
           'id': this.activeOrgId,
           'name': this.activeOrgName,
           'subscriptionState': pathOr('', ['organization', 'subscriptionState', 'type'], this.activeOrganization),
-          'features': pathOr([], ['organization', 'features'], this.activeOrganization).join(', ')
+          'features': pathOr([], ['organization', 'features'], this.activeOrganization).join(', '),
+          'environment': site.environment
         }
       });
     },


### PR DESCRIPTION
# Description
The purpose of this PR is to add the environment to Intercom. This will allow us to filter for users associated with companies in environment “Production”

## Clickup Ticket

[rz7y3z](https://app.clickup.com/t/rz7y3z)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Open the Network tab and filter by "intercom" (type this in)
- Locate a `ping` and scroll down to `Form Data` in the request
- `user_data` should pass an object, and `"environment":"local"` should be present

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
