### PR TITLE
fix(Reset Password): Loading state and timing

### DIFF
--- a/src/routes/ResetPassword/ResetPassword.vue
+++ b/src/routes/ResetPassword/ResetPassword.vue
@@ -131,7 +131,7 @@
               <bf-button
                 class="reset-pw-btn"
                 :processing="isResettingPassword"
-                processing-text="Saving"
+                :processing-text="resettingPasswordText"
                 @click="onPasswordFormSubmit"
               >
                 Reset Password
@@ -236,7 +236,8 @@ export default {
       isResettingPassword: false,
       isPasswordFormValid: false,
       tempEmail: '',
-      errorMsg: ''
+      errorMsg: '',
+      resettingPasswordText: 'Saving'
     }
   },
 
@@ -335,6 +336,8 @@ export default {
      * @param {Object} e
      */
     onPasswordFormSubmit: function(e) {
+      this.resettingPasswordText = 'Saving'
+
       this.$refs.passwordForm.validate(valid => {
         if (!valid) {
           return
@@ -347,11 +350,10 @@ export default {
       Auth.forgotPasswordSubmit(email, code, password)
         .then(() => {
           this.loginUser()
+          this.resettingPasswordText = 'Logging In'
         })
         .catch(error => {
           this.errorMsg = error.message
-        })
-        .finally(() =>  {
           this.isResettingPassword = false
         })
       })


### PR DESCRIPTION
# Description

The purpose of this PR is to fix an issue with the loading state when resetting the user's password. Before, the loading state would stop after the password was reset. The app then logs the user in automatically and this may appear to the user as if they have stalled out in the app.

https://user-images.githubusercontent.com/1493195/114938240-de38e980-9e0c-11eb-8e74-e7b03355ddaa.mp4

## Clickup Ticket

[rq8p8e](https://app.clickup.com/t/rq8p8e)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Reset your password
- Using the Network tab in devtools, [throttle your network](https://css-tricks.com/throttling-the-network/) to make the reset password request slow
- Reset your password using the code
- You should see a "Saving" state and then a "Logging In" state on the Save button

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
