### PR TITLE
Disable Two Factor Auth

### DIFF
--- a/src/components/my-settings/MySettingsContainer.vue
+++ b/src/components/my-settings/MySettingsContainer.vue
@@ -83,7 +83,7 @@
         class="divider"
       />
       <!-- two-factor auth -->
-      <el-row v-if="twoFactorDisabled">
+      <el-row v-if="isTwoFactorEnabled">
         <el-col :span="12">
           <h2>Two-Factor Authentication</h2>
           <el-row class="mb-20">
@@ -362,7 +362,7 @@ export default {
     return {
       apiKeys: [],
       isApiKeysLoading: true,
-      twoFactorDisabled: false,
+      isTwoFactorEnabled: false,
       ruleForm: {
         firstName: '',
         middleInitial: '',


### PR DESCRIPTION
# Description

The purpose of this PR is to disable two-factor authentication from a user's profile page.

## Clickup Ticket

[CU-r38y9t](https://app.clickup.com/t/CU-r38y9t)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Log into the platform with your account and go to the profile page. Two factor auth should no longer be visible.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
