### PR TITLE
fix(Documentation): FIx issue with timed out credentials

### DIFF
--- a/src/mixins/logout-handler/index.js
+++ b/src/mixins/logout-handler/index.js
@@ -13,6 +13,10 @@ export default {
      * 'logout' event callback
      */
     handleLogout: function(payload) {
+      if (this.$route.name === 'docs-login') {
+        return
+      }
+
       const shouldShowToast = defaultTo(false, prop('shouldShowToast', payload))
       const shouldRedirect = defaultTo(false, prop('shouldRedirect', payload))
 

--- a/src/routes/DocsLogin/DocsLogin.vue
+++ b/src/routes/DocsLogin/DocsLogin.vue
@@ -72,6 +72,9 @@ export default {
       this.sendXhr(`${this.config.apiUrl}/session/readme-credentials?api_key=${token}`, { method: 'GET' })
         .then(response => window.location.replace(`${this.config.docsUrl}?auth_token=${response}`))
         .catch(this.handleXhrError.bind(this))
+        .finally(() => {
+          this.isLoadingReadmeCredentials = false
+        })
     }
   }
 }


### PR DESCRIPTION
# Description

The purpose of this PR is to fix an issue with the Docs login URL when the saved token has timed out.

## Clickup Ticket

[td6xg6](https://app.clickup.com/t/td6xg6)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Go to http://localhost:3000 and [delete the `user_token` cookie using devtools](https://developer.chrome.com/docs/devtools/storage/cookies/#edit) to `123`
- Go to http://localhost:3000/docs-login
- Login with your credentials
- You should be redirected to the Pennsieve Docs and you should be logged in

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
