### PR TITLE
Hide Recaptcha Badge 

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -38,7 +38,8 @@ app.use(VueClipboard, {
 app.use(VueReCaptcha, {
     siteKey: siteConfig.reCAPTCHASiteKey,
     loaderOptions: {
-      explicitRenderParameters: {
+        autoHideBadge: true,
+        explicitRenderParameters: {
         badge: 'bottomright'
       }
     },

--- a/src/router/CreateAccount/CreateAccount.vue
+++ b/src/router/CreateAccount/CreateAccount.vue
@@ -71,11 +71,12 @@
               Privacy Policy
             </a>
           </p>
-          This site is protected by reCAPTCHA and the Google
-          <a href="https://policies.google.com/privacy">Privacy Policy</a> and
-          <a href="https://policies.google.com/terms">Terms of Service</a>
+          <p class="agreement">
+            This site is protected by reCAPTCHA and the Google
+            <a href="https://policies.google.com/privacy">Privacy Policy</a> and
+            <a href="https://policies.google.com/terms">Terms of Service</a>
           apply.
-          <p class="agreement"></p>
+          </p>
         </div>
         <div v-else>
           <h2 class="sharp-sans">Thank You</h2>

--- a/src/router/CreateAccount/CreateAccount.vue
+++ b/src/router/CreateAccount/CreateAccount.vue
@@ -70,8 +70,12 @@
             >
               Privacy Policy
             </a>
-            .
           </p>
+          This site is protected by reCAPTCHA and the Google
+          <a href="https://policies.google.com/privacy">Privacy Policy</a> and
+          <a href="https://policies.google.com/terms">Terms of Service</a>
+          apply.
+          <p class="agreement"></p>
         </div>
         <div v-else>
           <h2 class="sharp-sans">Thank You</h2>


### PR DESCRIPTION
This PR hides the ReCaptcha Badge on all pages, but adds the links to Google "terms of service" and "privacy policy" to be in compliance with Google's best practices for hiding the badge: 

[https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed](https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed)



