### PR TITLE
Remove changelog from settings page

### DIFF
--- a/src/components/datasets/settings/DatasetSettingsPublishing/StatusPublished.vue
+++ b/src/components/datasets/settings/DatasetSettingsPublishing/StatusPublished.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <p class="sharing-blurb">
+      
       Request to publish a new version of your dataset to Pennsieve Discover.
     </p>
     <p class="sharing-blurb">This requires approval by the Publishing team.</p>
@@ -14,65 +15,12 @@
           color="#000"
         />
         Published on {{ publishedDate }}
-        <a
-          target="_blank"
-          :href="discoverLink"
-          class="discover-link"
-        >
+        <a target="_blank" :href="discoverLink" class="discover-link">
           View on Discover
         </a>
       </p>
     </div>
-    <div v-if="hasCompletedChangelog">
-      <p>You have successfully saved the changelog and the dataset is ready to be submitted for review.</p>
-    </div>
-    <div v-else>
-      <p>NOTE: You have not yet saved a changelog file. Please consider completing and saving a changelog file below.</p>
-
-
-    <data-card
-      ref="changelogDataCard"
-      class="grey compact"
-      title="Changelog"
-      :is-expandable="true"
-      :padding="false"
-    >
-      <template slot="title-aux">
-        <button
-          v-if="isEditingMarkdown"
-          class="linked mr-8"
-          @click="isEditingMarkdown = false"
-        >
-          Cancel
-        </button>
-        <button
-          v-if="isEditingMarkdown"
-          class="linked"
-          @click="isSavingMarkdown = true"
-        >
-          Save
-        </button>
-        <button
-          v-else
-          slot="title-aux"
-          class="linked"
-          @click="isEditingMarkdown = true"
-        >
-          Update
-        </button>
-      </template>
-    <markdown-editor
-      ref="markdownEditor"
-      :value="changelogText"
-      :is-editing="isEditingMarkdown"
-      :is-saving="isSavingMarkdown"
-      :empty-state="changelogTextEmptyState"
-      :is-loading="isLoadingChangelog"
-      @save="onChangelogSave"
-    />
-    </data-card>
-    </div>
-    <br>
+    <br />
     <div class="published-btn-wrap mb-16">
       <submit-for-publication
         :has-dataset="true"
@@ -80,13 +28,13 @@
         :dataset-id="datasetId"
       />
     </div>
-    <p
-      v-if="!hasPublishingPermission"
-      class="sharing-blurb"
-    >
-      Editing capabilities such as releasing a new version or making a dataset private are restricted to owners only.
-      To change the owner of your dataset, please contact
-      <a :href="`mailto:${datasetOwnerEmail}?subject=Dataset Publishing Permissions`">
+    <p v-if="!hasPublishingPermission" class="sharing-blurb">
+      Editing capabilities such as releasing a new version or making a dataset
+      private are restricted to owners only. To change the owner of your
+      dataset, please contact
+      <a
+        :href="`mailto:${datasetOwnerEmail}?subject=Dataset Publishing Permissions`"
+      >
         {{ datasetOwnerName }}
       </a>
     </p>
@@ -94,19 +42,13 @@
 </template>
 
 <script>
-import {mapActions, mapGetters, mapState} from 'vuex'
-import SubmitForPublication from './SubmitForPublication.vue'
-import { PublicationTabs } from '../../../../utils/constants'
- // may need to change file path
-import DataCard from '../../../shared/DataCard/DataCard.vue'
-import MarkdownEditor from '../../../shared/MarkdownEditor/MarkdownEditor.vue'
-import changelogDescriptionEmptyState from './changelog-description-empty-state'
+import { mapState } from "vuex";
+import SubmitForPublication from "./SubmitForPublication.vue";
+import { PublicationTabs } from "../../../../utils/constants";
 
 export default {
   components: {
     SubmitForPublication,
-    DataCard,
-    MarkdownEditor,
   },
   props: {
     datasetId: {
@@ -136,77 +78,17 @@ export default {
     publishedDate: {
       type: String,
       required: true,
-    }
-  },
-  data() {
-    return {
-      hasCompletedChangelog: false,
-      changelogText: '',
-      isEditingMarkdown: false,
-      isSavingMarkdown: false,
-      changelogTextEmptyState: '',
-      isLoadingChangelog: false
-    }
+    },
   },
   computed: {
-    PublicationTabs: function() {
-      return PublicationTabs
+    PublicationTabs: function () {
+      return PublicationTabs;
     },
   },
   methods: {
-    ...mapActions(['setChangelogText']),
-    ...mapState([
-      'config',
-      'userToken'
-    ]),
-
-    datasetChangelogUrl: function() {
-      console.log("apiUrl")
-      console.log(this.config.apiUrl)
-      return this.userToken
-        ? `${this.config().apiUrl}/datasets/${this.datasetId}/changelog?api_key=${
-          this.userToken()
-        }`
-        : ''
-    },
-
-    /**
-     * On Changelog save, emitted from the MarkdownEditor
-     * Make a request to the API to save the changelog
-     * PUT request: URL, but it has a body with one element: changelog
-     * @params {String} markdown
-     */
-    onChangelogSave: function(markdown) {
-      fetch(this.datasetChangelogUrl(), {
-        body: JSON.stringify({
-          changelog: markdown
-        }),
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        }
-      })
-      //LEFT OFF HERE
-        .then(response => {
-          if (response.ok) {
-            //CHANGE THIS... set the changelog.body here
-            this.setChangelogText(markdown).finally(() => {
-              this.isSavingMarkdown = false
-              this.isEditingMarkdown = false
-              this.hasCompletedChangelog = true
-            })
-          } else if (response.status === 412) {
-            this.isSavingMarkdown = false
-            this.$refs.staleUpdateDialog.dialogVisible = true
-          } else {
-            throw response
-          }
-        })
-        .catch(this.handleXhrError.bind(this))
-    }
+    ...mapState(["config", "userToken"]),
   },
-}
-//TO UPDATE, need to perform a GET and modify with a PUT
+};
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
Ported over a https://github.com/Pennsieve/pennsieve-app/pull/275 we did Nov 9, 20203.

Description
Remove changelog from settings page

Clickup Ticket
[Bug: Changelog file should not be overwritten but amended, listing all events in a chronological order](https://app.clickup.com/8664796/v/l/li/901101104468)