### PR TITLE
adding getting-help and developer-tools pages

### DIFF
--- a/src/components/welcome/DeveloperTools.vue
+++ b/src/components/welcome/DeveloperTools.vue
@@ -5,22 +5,20 @@
   >
 
     <template #actions>
-      <a href="https://docs.pennsieve.io" target="_blank" class="mr-16"><bf-button>Visit Documentation Hub</bf-button></a>
+      <a href="https://docs.pennsieve.io/reference" target="_blank" class="mr-16"><bf-button>Visit API Reference</bf-button></a>
     </template>
-    <div>
-      <div class="highlight-image">
-        <img
-          src="/src/assets/images/illustrations/illo-dr_azumi_1.svg"
-          class="highlight"
-          alt="azumi"
-        />
-      </div>
-      <div
-        class='developer-docs'
-        v-html="docSummary"
-      />
 
+    <div class="highlight-image">
+      <img
+        src="/src/assets/images/illustrations/spot-blackfynn-view-package.svg"
+        class="highlight"
+        alt="azumi"
+      />
     </div>
+    <div
+    class='developer-docs'
+    v-html="docSummary"
+    />
 
   </bf-stage>
 </template>
@@ -54,7 +52,7 @@ export default {
   },
 
   mounted() {
-    this.getReadmeDocument('getting-help')
+    this.getReadmeDocument('developer-tools')
   },
 
   computed: {
@@ -74,6 +72,17 @@ export default {
 </script>
 
 <style scoped lang="scss">
+
+
+.highlight-image {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  .highlight {
+    height:80px;
+  }
+
+}
 
 h1 {
   font-size: 22px;
@@ -114,18 +123,8 @@ p {
   width: 500px;
 }
 
-.highlight-image {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  margin-bottom: 16px;
-  .highlight {
-    height:120px;
-  }
-
-}
-
 .developer-docs {
+  //border: 1px solid $purple_tint;
   padding: 8px;
   border-radius: 4px;
 

--- a/src/router/AboutPennsieve/AboutPennsieve.vue
+++ b/src/router/AboutPennsieve/AboutPennsieve.vue
@@ -62,6 +62,10 @@ export default {
           name: "Getting Help",
           to: "support"
         },
+        {
+          name: "Developer Tools",
+          to: "developer-tools"
+        },
 
 
       ]

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -69,6 +69,7 @@ const WelcomeInfo = () => import('../components/welcome/Welcome.vue')
 const SubmitDatasetPage = () => import('./welcomePage/SubmitDatasetPage.vue')
 const SubmitDatasets = () => import('../components/welcome/SubmitDatasets.vue')
 const CreateAccount = () => import('./CreateAccount/CreateAccount.vue')
+const DeveloperTools = () => import('../components/welcome/DeveloperTools.vue')
 
 
 const Viewer = () => import('../components/viewer/PsViewer/PsViewer.vue')
@@ -208,6 +209,13 @@ const router = createRouter({
           path: 'info',
           components: {
             stage: PennsieveInfo
+          }
+        },
+        {
+          name: 'developer-tools',
+          path: 'developer',
+          components: {
+            stage: DeveloperTools
           }
         },
       ]

--- a/src/router/welcomePage/WelcomePage.vue
+++ b/src/router/welcomePage/WelcomePage.vue
@@ -56,10 +56,6 @@ export default {
         {
           name: "My Public Datasets",
           to: "submit"
-        },
-        {
-          name: "Developer Tools",
-          to: "submit"
         }
       ]
     }


### PR DESCRIPTION
- Adding page for developer-tools
- Adding page for Getting Help

Both pages fetch content from Readme.io and therefore are very simple to update at a later stage.

<img width="990" alt="Screenshot 2024-03-17 at 10 04 35 PM" src="https://github.com/Pennsieve/pennsieve-app-2/assets/1605953/fd37a695-a6ef-4af7-8306-99f13bbb16e5">

<img width="988" alt="Screenshot 2024-03-17 at 10 06 54 PM" src="https://github.com/Pennsieve/pennsieve-app-2/assets/1605953/bd70572e-65d0-4437-9c62-3a2756d59748">

