### PR TITLE
added width and padding styles to the contact us page

### DIFF
--- a/src/components/shared/PennsieveHeader/contact-us-dialog/ContactUsDialog.vue
+++ b/src/components/shared/PennsieveHeader/contact-us-dialog/ContactUsDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <el-dialog v-model="isOpen" @close="closeDialog">
+  <el-dialog class="contact-us-dialog" v-model="isOpen" @close="closeDialog">
     <template #header>
       <bf-dialog-header title="Contact Us" />
     </template>
@@ -114,9 +114,15 @@ export default {
   },
 };
 </script>
-
+<style lang="scss">
+  .contact-us-dialog{
+    width:540px;
+    padding:0;
+  }
+</style>
 <style scoped lang="scss">
 @import "../../../../assets/_variables.scss";
+
 .margin-top {
   margin-top: 10px;
 }


### PR DESCRIPTION
ticket: https://app.clickup.com/t/8687xqj98
bug fix - contact us dialog needed style changes

Files Changed

- contact-us-dialog/ContactUsDialog.vue

notes: had to add an un-scoped style tag to reach the el-dialog element. not ideal way to do it, but might be a known bug in Element-Plus [issue](https://github.com/element-plus/element-plus/issues/5383) I've ran into it before but have not found a better solution. 